### PR TITLE
Add ability to sync Google Workspace Directory contacts

### DIFF
--- a/_locales/en-US/messages.json
+++ b/_locales/en-US/messages.json
@@ -42,6 +42,9 @@
     "pref.readOnlyMode": {
         "message": "Read-only mode"
     },
+    "pref.includeDirectoryContacts": {
+        "message": "Include domain directory contacts (always read-only)"
+    },
     "pref.useFakeEmailAddresses": {
         "message": "Use fake email addresses"
     },

--- a/content/includes/AddressBookSynchronizer.js
+++ b/content/includes/AddressBookSynchronizer.js
@@ -49,6 +49,7 @@ class AddressBookSynchronizer {
         // Retrieve other account properties.
         let useFakeEmailAddresses = syncData.accountData.getAccountProperty("useFakeEmailAddresses");
         let readOnlyMode = syncData.accountData.getAccountProperty("readOnlyMode");
+        let includeDirectoryContacts = syncData.accountData.getAccountProperty("includeDirectoryContacts");
         let verboseLogging = syncData.accountData.getAccountProperty("verboseLogging");
         // Enable the logger.
         logger = new Logger(verboseLogging);
@@ -80,6 +81,10 @@ class AddressBookSynchronizer {
             logger.log0("AddressBookSynchronizer.synchronize(): Synchronization started.");
             // Synchronize contacts.
             await AddressBookSynchronizer.synchronizeContacts(peopleAPI, targetAddressBook, targetAddressBookItemMap, contactGroupMemberMap, addedLocalItemIds, modifiedLocalItemIds, deletedLocalItemIds, useFakeEmailAddresses, readOnlyMode);
+            if (includeDirectoryContacts) {
+                // Synchronize directory contacts.
+                await AddressBookSynchronizer.synchronizeDirectoryContacts(peopleAPI, targetAddressBook, contactGroupMemberMap, useFakeEmailAddresses);
+            }
             // Synchronize contact groups.
             await AddressBookSynchronizer.synchronizeContactGroups(peopleAPI, targetAddressBook, targetAddressBookItemMap, addedLocalItemIds, modifiedLocalItemIds, deletedLocalItemIds, readOnlyMode);
             // Synchronize contact group members.
@@ -322,6 +327,44 @@ class AddressBookSynchronizer {
         }
     }
 
+    static async synchronizeDirectoryContacts(peopleAPI, targetAddressBook, contactGroupMemberMap, useFakeEmailAddresses) {
+        if (null == peopleAPI) {
+            throw new IllegalArgumentError("Invalid 'peopleAPI': null.");
+        }
+        if (null == targetAddressBook) {
+            throw new IllegalArgumentError("Invalid 'targetAddressBook': null.");
+        }
+        if (null == contactGroupMemberMap) {
+            throw new IllegalArgumentError("Invalid 'contactGroupMemberMap': null.");
+        }
+        if (null == useFakeEmailAddresses) {
+            throw new IllegalArgumentError("Invalid 'useFakeEmailAddresses': null.");
+        }
+        // Retrieve all server contacts.
+        let serverContacts = await peopleAPI.getDirectoryContacts();
+        // Cycle on the server contacts.
+        logger.log1("AddressBookSynchronizer.synchronizeDirectoryContacts(): Cycling on the server contacts.");
+        for (let serverContact of serverContacts) {
+            // Get the resource name (in the form 'people/personId') and the display name.
+            let resourceName = serverContact.resourceName;
+            let displayName = (serverContact.names ? serverContact.names[0].displayName : "-");
+            logger.log1("AddressBookSynchronizer.synchronizeDirectoryContacts(): " + resourceName + " (" + displayName + ")");
+            let localContact = targetAddressBook.createNewCard();
+            // Import the server contact information into the local contact.
+            localContact.setProperty("X-GOOGLE-RESOURCENAME", resourceName);
+            localContact.setProperty("X-GOOGLE-ETAG", serverContact.etag);
+            localContact = AddressBookSynchronizer.fillLocalContactWithServerContactInformation(localContact, serverContact, useFakeEmailAddresses);
+            // Add the local contact locally, keep the target address book item map up-to-date.
+            await targetAddressBook.addItem(localContact, true);
+           logger.log1("AddressBookSynchronizer.synchronizeDirectoryContacts(): " + resourceName + " (" + displayName + ") has been added locally.");
+            // Remove the resource name from the local change log (added items).
+            // (This should be logically useless, but sometimes the change log is filled with some of the contacts added above.)
+            await targetAddressBook.removeItemFromChangeLog(resourceName);
+            // Update the contact group member map.
+            AddressBookSynchronizer.updateContactGroupMemberMap(contactGroupMemberMap, resourceName, serverContact.memberships);
+        }
+    }
+
     static fillLocalContactWithServerContactInformation(localContact, serverContact, useFakeEmailAddresses) {
         if (null == localContact) {
             throw new IllegalArgumentError("Invalid 'localContact': null.");
@@ -355,7 +398,8 @@ class AddressBookSynchronizer {
             let name_found = false;
             let name = null;
             for (name of serverContact.names) {
-                if ("CONTACT" === name.metadata.source.type) {
+                if ("CONTACT" === name.metadata.source.type ||
+                    "PROFILE" === name.metadata.source.type || "DOMAIN_PROFILE" === name.metadata.source.type || "DOMAIN_CONTACT" === name.metadata.source.type) {
                     name_found = true;
                     break;
                 }
@@ -409,7 +453,8 @@ class AddressBookSynchronizer {
             let pref_param = "1";
             //
             for (let emailAddress of serverContact.emailAddresses) {
-                if ("CONTACT" !== emailAddress.metadata.source.type) {
+                if (!("CONTACT" === emailAddress.metadata.source.type ||
+                    "PROFILE" === emailAddress.metadata.source.type || "DOMAIN_PROFILE" === emailAddress.metadata.source.type || "DOMAIN_CONTACT" === emailAddress.metadata.source.type)) {
                     continue;
                 }
                 //

--- a/content/includes/AddressBookSynchronizer.js
+++ b/content/includes/AddressBookSynchronizer.js
@@ -344,7 +344,7 @@ class AddressBookSynchronizer {
         let serverContacts = await peopleAPI.getDirectoryContacts();
         // Cycle on the server contacts.
         logger.log1("AddressBookSynchronizer.synchronizeDirectoryContacts(): Cycling on the server contacts.");
-        for (let serverContact of serverContacts) {
+        await Promise.all(serverContacts.map(async (serverContact) => {
             // Get the resource name (in the form 'people/personId') and the display name.
             let resourceName = serverContact.resourceName;
             let displayName = (serverContact.names ? serverContact.names[0].displayName : "-");
@@ -362,7 +362,7 @@ class AddressBookSynchronizer {
             await targetAddressBook.removeItemFromChangeLog(resourceName);
             // Update the contact group member map.
             AddressBookSynchronizer.updateContactGroupMemberMap(contactGroupMemberMap, resourceName, serverContact.memberships);
-        }
+        }))
     }
 
     static fillLocalContactWithServerContactInformation(localContact, serverContact, useFakeEmailAddresses) {

--- a/content/includes/AddressBookSynchronizer.js
+++ b/content/includes/AddressBookSynchronizer.js
@@ -83,7 +83,7 @@ class AddressBookSynchronizer {
             await AddressBookSynchronizer.synchronizeContacts(peopleAPI, targetAddressBook, targetAddressBookItemMap, contactGroupMemberMap, addedLocalItemIds, modifiedLocalItemIds, deletedLocalItemIds, useFakeEmailAddresses, readOnlyMode);
             if (includeDirectoryContacts) {
                 // Synchronize directory contacts.
-                await AddressBookSynchronizer.synchronizeDirectoryContacts(peopleAPI, targetAddressBook, contactGroupMemberMap, useFakeEmailAddresses);
+                await AddressBookSynchronizer.synchronizeDirectoryContacts(peopleAPI, targetAddressBook, targetAddressBookItemMap, contactGroupMemberMap, useFakeEmailAddresses);
             }
             // Synchronize contact groups.
             await AddressBookSynchronizer.synchronizeContactGroups(peopleAPI, targetAddressBook, targetAddressBookItemMap, addedLocalItemIds, modifiedLocalItemIds, deletedLocalItemIds, readOnlyMode);
@@ -179,7 +179,7 @@ class AddressBookSynchronizer {
                     // (This should be logically useless, but sometimes the change log is filled with some of the contacts added above.)
                     await targetAddressBook.removeItemFromChangeLog(resourceName);
                     // Update the contact group member map.
-                    AddressBookSynchronizer.updateContactGroupMemberMap(contactGroupMemberMap, resourceName, serverContact.memberships);
+                    AddressBookSynchronizer.updateContactGroupMemberMap(contactGroupMemberMap, resourceName, serverContact.memberships, false);
                 }
             }
             // If such a local contact is currently available...
@@ -197,7 +197,7 @@ class AddressBookSynchronizer {
                     await targetAddressBook.removeItemFromChangeLog(resourceName);
                 }
                 // Update the contact group member map.
-                AddressBookSynchronizer.updateContactGroupMemberMap(contactGroupMemberMap, resourceName, serverContact.memberships);
+                AddressBookSynchronizer.updateContactGroupMemberMap(contactGroupMemberMap, resourceName, serverContact.memberships, false);
             }
         }
         // Prepare the variables for the cycles.
@@ -327,7 +327,7 @@ class AddressBookSynchronizer {
         }
     }
 
-    static async synchronizeDirectoryContacts(peopleAPI, targetAddressBook, contactGroupMemberMap, useFakeEmailAddresses) {
+    static async synchronizeDirectoryContacts(peopleAPI, targetAddressBook, targetAddressBookItemMap, contactGroupMemberMap, useFakeEmailAddresses) {
         if (null == peopleAPI) {
             throw new IllegalArgumentError("Invalid 'peopleAPI': null.");
         }
@@ -337,9 +337,26 @@ class AddressBookSynchronizer {
         if (null == contactGroupMemberMap) {
             throw new IllegalArgumentError("Invalid 'contactGroupMemberMap': null.");
         }
+        if (null == targetAddressBookItemMap) {
+            throw new IllegalArgumentError("Invalid 'targetAddressBookItemMap': null.");
+        }
         if (null == useFakeEmailAddresses) {
             throw new IllegalArgumentError("Invalid 'useFakeEmailAddresses': null.");
         }
+
+        // Create the _Directory mailing list (contact group) if it does not already exist.
+        let localContactGroup = targetAddressBookItemMap.get("_Directory");
+        if (undefined === localContactGroup) {
+            localContactGroup = targetAddressBook.createNewList();
+            localContactGroup.setProperty("X-GOOGLE-RESOURCENAME", "_Directory");
+            localContactGroup.setProperty("ListName", "_Directory");
+            // Add the local contact group locally, and keep the target address book item map up-to-date.
+            await targetAddressBook.addItem(localContactGroup, true);
+            targetAddressBookItemMap.set("_Directory", localContactGroup);
+            logger.log1("AddressBookSynchronizer.synchronizeContactGroups(): _Directory has been added locally.");
+        }
+        await targetAddressBook.removeItemFromChangeLog("_Directory");
+
         // Retrieve all server contacts.
         let serverContacts = await peopleAPI.getDirectoryContacts();
         // Cycle on the server contacts.
@@ -355,13 +372,14 @@ class AddressBookSynchronizer {
             localContact.setProperty("X-GOOGLE-ETAG", serverContact.etag);
             localContact = AddressBookSynchronizer.fillLocalContactWithServerContactInformation(localContact, serverContact, useFakeEmailAddresses);
             // Add the local contact locally, keep the target address book item map up-to-date.
-            await targetAddressBook.addItem(localContact, true);
-           logger.log1("AddressBookSynchronizer.synchronizeDirectoryContacts(): " + resourceName + " (" + displayName + ") has been added locally.");
+            await targetAddressBook.addItem(localContact, true)
+            targetAddressBookItemMap.set(resourceName, localContact);;
+            logger.log1("AddressBookSynchronizer.synchronizeDirectoryContacts(): " + resourceName + " (" + displayName + ") has been added locally.");
             // Remove the resource name from the local change log (added items).
             // (This should be logically useless, but sometimes the change log is filled with some of the contacts added above.)
             await targetAddressBook.removeItemFromChangeLog(resourceName);
             // Update the contact group member map.
-            AddressBookSynchronizer.updateContactGroupMemberMap(contactGroupMemberMap, resourceName, serverContact.memberships);
+            AddressBookSynchronizer.updateContactGroupMemberMap(contactGroupMemberMap, resourceName, serverContact.memberships, true);
         }))
     }
 
@@ -1400,6 +1418,11 @@ abManager.deleteAddressBook(localContactGroup._card.mailListURI);
             if (localContactGroupFoundAmongServerContactGroups) {
                 continue;
             }
+            // Check that we are not deleting _Directory
+            if (localContactGroupId.startsWith("_Directory")) {
+                logger.log1("AddressBookSynchronizer.synchronizeContactGroups(): " + localContactGroupId + " (" + name + ") is a _Directory contact group and has therefore been ignored.");
+                continue;
+            }
             // Delete the local contact group locally, and keep the target address book item map up-to-date.
 /* FIXME: temporary: .deleteItem() does not actually delete a contact group.
             targetAddressBook.deleteItem(localContactGroup, true);
@@ -1500,7 +1523,7 @@ abManager.deleteAddressBook(localContactGroup._card.mailListURI);
         }
     }
 
-    static updateContactGroupMemberMap(contactGroupMemberMap, contactResourceName, contactMemberships) {
+    static updateContactGroupMemberMap(contactGroupMemberMap, contactResourceName, contactMemberships, isDirectoryContact) {
         if (null == contactGroupMemberMap) {
             throw new IllegalArgumentError("Invalid 'contactGroupMemberMap': null.");
         }
@@ -1526,6 +1549,14 @@ abManager.deleteAddressBook(localContactGroup._card.mailListURI);
             }
             // Add the contact to the map.
             contactGroupMemberMap.get(contactGroupResourceName).add(contactResourceName);
+        }
+        if (isDirectoryContact) {
+            // Make sure the contact is also a member of the _Directory contact group.
+            let directoryContactGroupResourceName = "_Directory";
+            if (undefined === contactGroupMemberMap.get(directoryContactGroupResourceName)) {
+                contactGroupMemberMap.set(directoryContactGroupResourceName, new Set());
+            }
+            contactGroupMemberMap.get(directoryContactGroupResourceName).add(contactResourceName);
         }
     }
 

--- a/content/includes/AddressBookSynchronizer.js
+++ b/content/includes/AddressBookSynchronizer.js
@@ -1508,7 +1508,9 @@ abManager.deleteAddressBook(localContactGroup._card.mailListURI);
             throw new IllegalArgumentError("Invalid 'contactResourceName': null.");
         }
         if (null == contactMemberships) {
-            throw new IllegalArgumentError("Invalid 'contactMemberships': null.");
+            // Some DIRECTORY_SOURCE_TYPE_DOMAIN_CONTACT contacts do not have any membership.
+            logger.log0("AddressBookSynchronizer.updateContactGroupMemberMap(): No contact memberships for " + contactResourceName + ".");
+            return;
         }
         // Cycle on all contact memberships.
         for (let contactMembership of contactMemberships) {

--- a/content/includes/PeopleAPI.js
+++ b/content/includes/PeopleAPI.js
@@ -27,7 +27,7 @@ if ("undefined" === typeof ResponseError) {
 
 let { MailE10SUtils } = ChromeUtils.importESModule("resource:///modules/MailE10SUtils.sys.mjs");
 
-const SCOPES = "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/contacts"; // https://developers.google.com/people/v1/how-tos/authorizing
+const SCOPES = "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/contacts https://www.googleapis.com/auth/directory.readonly"; // https://developers.google.com/people/v1/how-tos/authorizing
 const SERVICE_ENDPOINT = "https://people.googleapis.com";
 const CONTACT_PERSON_FIELDS = "names,nicknames,emailAddresses,phoneNumbers,addresses,organizations,urls,birthdays,userDefined,imClients,biographies,memberships";
 const CONTACT_UPDATE_PERSON_FIELDS = "names,nicknames,emailAddresses,phoneNumbers,addresses,organizations,urls,birthdays,userDefined,imClients,biographies"; // no 'memberships' here
@@ -502,6 +502,50 @@ class PeopleAPI {
         return true;
     }
 
+    /* Directory Contacts */
+    async getDirectoryContacts() { // https://developers.google.com/people/api/rest/v1/people/listDirectoryPeople
+        // Get a new access token.
+        let accessToken = await this.getNewAccessToken();
+        // Retrieve the contacts page by page.
+        let contacts = [];
+        let nextPageToken = null;
+        while (true) {
+            logger.log1("PeopleAPI.getDirectoryContacts(): nextPageToken = " + nextPageToken);
+            // Prepare the partial contact request URL and data.
+            let partialContactRequestURL = SERVICE_ENDPOINT + "/v1/people:listDirectoryPeople";
+            partialContactRequestURL += "?" + PeopleAPI.getObjectAsEncodedURIParameters({
+                readMask: CONTACT_PERSON_FIELDS,
+                pageSize: CONTACT_PAGE_SIZE,
+                mergeSources: "DIRECTORY_MERGE_SOURCE_TYPE_CONTACT",
+                access_token: accessToken,
+                sources: "DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE"
+            }) + "&" + PeopleAPI.getObjectAsEncodedURIParameters({
+                sources: "DIRECTORY_SOURCE_TYPE_DOMAIN_CONTACT"
+            });
+            if (null != nextPageToken) {
+                partialContactRequestURL += "&pageToken=" + encodeURIComponent(nextPageToken);
+            }
+            let partialContactRequestData = null;
+            // Perform the request and retrieve the response data.
+            let responseData = await this.getResponseData("GET", partialContactRequestURL, partialContactRequestData);
+            // Retrieve the partial contacts.
+            let partialContacts = responseData.people;
+            // Concatenate the partial contacts with the contacts.
+            if (null != partialContacts) {
+                contacts = contacts.concat(partialContacts);
+            }
+            // Retrieve the next page token, necessary to retrieve the next page.
+            nextPageToken = responseData.nextPageToken;
+            // Check if this was the last page.
+            if (null == nextPageToken) {
+                break;
+            }
+        }
+        //
+        logger.log1("PeopleAPI.getDirectoryContacts(): contacts = " + JSON.stringify(contacts));
+        return contacts;
+    }
+
     /* Connection tests. */
 
     checkConnection() {
@@ -513,6 +557,13 @@ class PeopleAPI {
                 let authenticatedUserEmail = authenticatedUser.emailAddresses[0].value;
                 //
                 let contacts = await this.getContacts();
+                let directoryContacts;
+                try {
+                    directoryContacts = await this.getDirectoryContacts();
+                } catch (error) {
+                    directoryContacts = [];
+                    alert("Warning: Unable to retrieve directory contacts. If you are not using a Google Workspace account, this is expected.");
+                }
                 let contactGroups = await this.getContactGroups();
                 //
                 let systemContactGroupCount = 0;
@@ -522,7 +573,7 @@ class PeopleAPI {
                     }
                 }
                 //
-                alert("Hi " + authenticatedUserName + " (" + authenticatedUserEmail + ").\nYou have " + contacts.length + " contacts and " + (contactGroups.length - (this.getIncludeSystemContactGroups() ? 0 : systemContactGroupCount)) + " contact groups.");
+                alert("Hi " + authenticatedUserName + " (" + authenticatedUserEmail + ").\nYou have " + contacts.length + " contacts, " + directoryContacts.length + " directory contacts, and " + (contactGroups.length - (this.getIncludeSystemContactGroups() ? 0 : systemContactGroupCount)) + " contact groups.");
             }
             catch (error) {
                 // If a network error was encountered...

--- a/content/manager/createAccount.js
+++ b/content/manager/createAccount.js
@@ -27,6 +27,7 @@ var tbSyncNewAccount = {
     clientSecretWidget: null,
     includeSystemContactGroupsWidget: null,
     useFakeEmailAddressesWidget: null,
+    includeDirectoryContactsWidget: null,
     readOnlyModeWidget: null,
     verboseLoggingWidget: null,
 
@@ -42,6 +43,7 @@ var tbSyncNewAccount = {
         this.includeSystemContactGroupsWidget = document.getElementById('tbsync.newaccount.includeSystemContactGroups');
         this.useFakeEmailAddressesWidget = document.getElementById('tbsync.newaccount.useFakeEmailAddresses');
         this.readOnlyModeWidget = document.getElementById('tbsync.newaccount.readOnlyMode');
+        this.includeDirectoryContactsWidget = document.getElementById('tbsync.newaccount.includeDirectoryContacts');
         this.verboseLoggingWidget = document.getElementById('tbsync.newaccount.verboseLogging');
         //
         this.accountNameWidget.value = "";
@@ -50,6 +52,7 @@ var tbSyncNewAccount = {
         this.includeSystemContactGroupsWidget.checked = false;
         this.useFakeEmailAddressesWidget.checked = false;
         this.readOnlyModeWidget.checked = true;
+        this.includeDirectoryContactsWidget.checked = false;
         this.verboseLoggingWidget.checked = false;
         //
         document.getElementById("tbsync.newaccount.wizard").canRewind = false;
@@ -78,12 +81,13 @@ var tbSyncNewAccount = {
         let includeSystemContactGroups = this.includeSystemContactGroupsWidget.checked;
         let useFakeEmailAddresses = this.useFakeEmailAddressesWidget.checked;
         let readOnlyMode = this.readOnlyModeWidget.checked;
+        let includeDirectoryContacts = this.includeDirectoryContactsWidget.checked;
         let verboseLogging = this.verboseLoggingWidget.checked;
         //
-        tbSyncNewAccount.addAccount(accountName, clientID, clientSecret, includeSystemContactGroups, useFakeEmailAddresses, readOnlyMode, verboseLogging);
+        tbSyncNewAccount.addAccount(accountName, clientID, clientSecret, includeSystemContactGroups, useFakeEmailAddresses, readOnlyMode, includeDirectoryContacts, verboseLogging);
     },
 
-    addAccount: function (accountName, clientID, clientSecret, includeSystemContactGroups, useFakeEmailAddresses, readOnlyMode, verboseLogging) {
+    addAccount: function (accountName, clientID, clientSecret, includeSystemContactGroups, useFakeEmailAddresses, readOnlyMode, includeDirectoryContacts, verboseLogging) {
         // Retrieve a new object with default values.
         let newAccountEntry = this.providerData.getDefaultAccountEntries();
         // Override the default values.
@@ -92,6 +96,7 @@ var tbSyncNewAccount = {
         newAccountEntry.includeSystemContactGroups = includeSystemContactGroups;
         newAccountEntry.useFakeEmailAddresses = useFakeEmailAddresses;
         newAccountEntry.readOnlyMode = readOnlyMode;
+        newAccountEntry.includeDirectoryContacts = includeDirectoryContacts;
         newAccountEntry.verboseLogging = verboseLogging;
         // Add the new account.
         let newAccountData = this.providerData.addAccount(accountName, newAccountEntry);

--- a/content/manager/createAccount.xhtml
+++ b/content/manager/createAccount.xhtml
@@ -100,6 +100,18 @@
                     <html:tr>
                         <html:td>
                             <vbox pack="center">
+                                <label value="__GOOGLE4TBSYNCMSG_pref.includeDirectoryContacts__" />
+                            </vbox>
+                        </html:td>
+                        <html:td>
+                            <vbox pack="center">
+                                <html:input type="checkbox" id="tbsync.newaccount.includeDirectoryContacts" />
+                            </vbox>
+                        </html:td>
+                    </html:tr>
+                    <html:tr>
+                        <html:td>
+                            <vbox pack="center">
                                 <label value="__GOOGLE4TBSYNCMSG_pref.verboseLogging__" />
                             </vbox>
                         </html:td>

--- a/content/manager/editAccountOverlay.js
+++ b/content/manager/editAccountOverlay.js
@@ -27,6 +27,7 @@ var tbSyncEditAccountOverlay = {
     includeSystemContactGroupsWidget: null,
     useFakeEmailAddressesWidget: null,
     readOnlyModeWidget: null,
+    includeDirectoryContactsWidget: null,
     verboseLoggingWidget: null,
 /*
     checkConnectionWidget: null,
@@ -41,6 +42,7 @@ var tbSyncEditAccountOverlay = {
         this.includeSystemContactGroupsWidget = document.getElementById('tbsync.accountsettings.pref.includeSystemContactGroups');
         this.useFakeEmailAddressesWidget = document.getElementById('tbsync.accountsettings.pref.useFakeEmailAddresses');
         this.readOnlyModeWidget = document.getElementById('tbsync.accountsettings.pref.readOnlyMode');
+        this.includeDirectoryContactsWidget = document.getElementById('tbsync.accountsettings.pref.includeDirectoryContacts');
         this.verboseLoggingWidget = document.getElementById('tbsync.accountsettings.pref.verboseLogging');
         //
         this.accountNameWidget.value = this.accountData.getAccountProperty("accountname");
@@ -49,6 +51,7 @@ var tbSyncEditAccountOverlay = {
         this.includeSystemContactGroupsWidget.checked = this.accountData.getAccountProperty("includeSystemContactGroups");
         this.useFakeEmailAddressesWidget.checked = this.accountData.getAccountProperty("useFakeEmailAddresses");
         this.readOnlyModeWidget.checked = this.accountData.getAccountProperty("readOnlyMode");
+        this.includeDirectoryContactsWidget.checked = this.accountData.getAccountProperty("includeDirectoryContacts");
         this.verboseLoggingWidget.checked = this.accountData.getAccountProperty("verboseLogging");
     },
 
@@ -71,6 +74,9 @@ var tbSyncEditAccountOverlay = {
                 break;
             case "readOnlyMode":
                 this.accountData.setAccountProperty("readOnlyMode", this.readOnlyModeWidget.checked);
+                break;
+            case "includeDirectoryContacts":
+                this.accountData.setAccountProperty("includeDirectoryContacts", this.includeDirectoryContactsWidget.checked);
                 break;
             case "verboseLogging":
                 this.accountData.setAccountProperty("verboseLogging", this.verboseLoggingWidget.checked);

--- a/content/manager/editAccountOverlay.xhtml
+++ b/content/manager/editAccountOverlay.xhtml
@@ -97,6 +97,18 @@
                 <html:tr>
                     <html:td>
                         <vbox pack="center">
+                            <label class="lockIfConnected" style="text-align: left;" control="tbsync.accountsettings.pref.includeDirectoryContacts" value="__GOOGLE4TBSYNCMSG_pref.includeDirectoryContacts__" />
+                        </vbox>
+                    </html:td>
+                    <html:td>
+                        <vbox pack="center">
+                            <html:input type="checkbox" id="tbsync.accountsettings.pref.includeDirectoryContacts" class="lockIfConnected" onchange="tbSyncEditAccountOverlay.updateAccountProperty('includeDirectoryContacts');" />
+                        </vbox>
+                    </html:td>
+                </html:tr>
+                <html:tr>
+                    <html:td>
+                        <vbox pack="center">
                             <label class="lockIfConnected" style="text-align: left;" control="tbsync.accountsettings.pref.verboseLogging" value="__GOOGLE4TBSYNCMSG_pref.verboseLogging__" />
                         </vbox>
                     </html:td>

--- a/content/provider.js
+++ b/content/provider.js
@@ -196,6 +196,7 @@ var Base = class {
             includeSystemContactGroups: false,
             useFakeEmailAddresses: false,
             readOnlyMode: true,
+            includeDirectoryContacts: false,
             verboseLogging: false,
             refreshToken: null,
         };


### PR DESCRIPTION
Partially Closes #33 
Currently, directory contacts are put alongside regular contacts with no way of discerning between them. Future work may be to, as @theblackhole suggested, add all directory contacts to a mailing list to separate them in the UI.